### PR TITLE
install_go: update go to 1.19

### DIFF
--- a/buildpack/scripts/install_go.sh
+++ b/buildpack/scripts/install_go.sh
@@ -12,8 +12,8 @@ function main() {
   fi
 
   local version expected_sha dir
-  version="1.15.5"
-  expected_sha="fd04494f7a2dd478b0d31cb949aae7f154749cae1242581b1574f7e590b3b7e6"
+  version="1.19"
+  expected_sha="7e231ea5c68f4be7fea916d27814cc34b95e78c4664c3eb2411e8370f87558bd"
   dir="/tmp/go${version}"
 
   mkdir -p "${dir}"


### PR DESCRIPTION
Not undrafting this now because toolsmiths seem to be out of cf-deployment envs at the moment (https://environments.toolsmiths.cf-app.com/pooled_gcp_environments)

This change will trigger all buildpacks to run their tests at the same time demanding some 11 cf-deployment envs