### PR TITLE
integration.sh: pass stack to packaging script

### DIFF
--- a/buildpack/scripts/integration.sh
+++ b/buildpack/scripts/integration.sh
@@ -105,7 +105,7 @@ function specs::run() {
   fi
 
   local buildpack_file
-  buildpack_file="$(buildpack::package "1.2.3" "${cached}")"
+  buildpack_file="$(buildpack::package "1.2.3" "${cached}" "${stack}")"
 
   CF_STACK="${stack}" \
   BUILDPACK_FILE="${BUILDPACK_FILE:-"${buildpack_file}"}" \
@@ -127,13 +127,14 @@ function buildpack::package() {
   local version cached
   version="${1}"
   cached="${2}"
+  stack="${3}"
 
   local name cached_flag
-  name="buildpack-v${version}-uncached.zip"
+  name="buildpack-${stack}-v${version}-uncached.zip"
   cached_flag=""
   if [[ "${cached}" == "true" ]]; then
     cached_flag="--cached"
-    name="buildpack-v${version}-cached.zip"
+    name="buildpack-${stack}-v${version}-cached.zip"
   fi
 
   local output
@@ -142,6 +143,7 @@ function buildpack::package() {
   bash "${ROOTDIR}/scripts/package.sh" \
     --version "${version}" \
     --output "${output}" \
+    --stack "${stack}" \
     "${cached_flag}" > /dev/null
 
   printf "%s" "${output}"


### PR DESCRIPTION
Without passing the stack to package.sh, it creates a superset buildpack of "any" stack.

We are interested in tests with buildpack packaged against a single stack.

This came to light with a python test failure that was temporarily fixed by disabling the python dependency-update pipeline, and applying this fix (https://github.com/cloudfoundry/python-buildpack/commits/93adac0cf83864efabdbc22178971559b9d66d41)