### PR TITLE
add workflow to create monthly issues to release CF buildpacks

### DIFF
--- a/buildpack/.github/workflows/release-reminder.yml
+++ b/buildpack/.github/workflows/release-reminder.yml
@@ -1,0 +1,54 @@
+name: Release Reminder
+
+on:
+  schedule:
+    - cron: '45 0 1 * *'
+  workflow_dispatch: {}
+
+jobs:
+  reminder:
+    name: Reminder
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get Month
+        id: month
+        run: |
+          echo "month=$(date +%b)" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.CF_BOT_GITHUB_TOKEN }}
+          ref: develop
+          fetch-depth: 0
+
+      - name: Get Latest Version
+        id: latest-version
+        run: |
+          echo "val=$(git describe --abbrev=0 --tag)" >> "${GITHUB_OUTPUT}"
+
+      - name: File Issue
+        id: file-issue
+        uses: paketo-buildpacks/github-config/actions/issue/file@main
+        with:
+          token: ${{ secrets.CF_BOT_GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          issue_title: "Release: ${{ github.event.repository.name }} (${{ steps.month.outputs.month }})"
+          issue_body: |
+            Release reminder for ${{ github.event.repository.name }}
+
+            * See [diff from latest version]("https://github.com/${{ github.repository }}/compare/${{ steps.latest-version.outputs.val }}..develop") and validate if a release is required.
+            * Make sure the latest commit on `develop` has passed tests on the [CI](https://buildpacks.ci.cf-app.com/teams/main/pipelines/${{ github.event.repository.name }})
+            * Refer [release instructions](https://github.com/pivotal-cf/tanzu-buildpacks/wiki/Releasing-CF-Buildpacks). (private link)
+
+      - name: Add issue to project
+        id: issue-to-proj
+        uses: paketo-buildpacks/github-config/actions/issue/add-to-project@main
+        with:
+          # CF buildpacks project - https://github.com/orgs/cloudfoundry/projects/37
+          project-org: cloudfoundry
+          project-num: 37
+          field-name: Workstream
+          option-name: Release Train
+          issue-node-id: ${{ steps.file-issue.outputs.node-id }}
+          token: ${{ secrets.CF_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
GH worklow creates an issue on the buildpack repo on each cycle, and adds it to the "Release Train" workstream on the [CF Buildpack Workstreams board](https://github.com/orgs/cloudfoundry/projects/37)

Closes https://github.com/cloudfoundry/buildpacks-ci/issues/213

--
Tested out at https://github.com/cloudfoundry/binary-buildpack/actions/runs/4000769118/jobs/6866300448.
Made minor fixes from the test run.