### PR TITLE
release-reminder: task to bump modules just for PHP

### DIFF
--- a/buildpack/.github/workflows/release-reminder.yml
+++ b/buildpack/.github/workflows/release-reminder.yml
@@ -27,6 +27,12 @@ jobs:
         run: |
           echo "val=$(git describe --abbrev=0 --tag)" >> "${GITHUB_OUTPUT}"
 
+      - name: PHP specific task
+        id: php-specific
+        if: github.repository == 'cloudfoundry/php-buildpack'
+        run: |
+          echo 'task=* Bump PHP modules. See [doc](https://github.com/cloudfoundry/buildpacks-ci/tree/master/scripts/php-modules#pre-buildpack-release-task)' >> "${GITHUB_OUTPUT}"
+
       - name: File Issue
         id: file-issue
         uses: paketo-buildpacks/github-config/actions/issue/file@main
@@ -37,6 +43,7 @@ jobs:
           issue_body: |
             Release reminder for ${{ github.event.repository.name }}
 
+            ${{ steps.php-specific.outputs.task }}
             * See [diff from latest version]("https://github.com/${{ github.repository }}/compare/${{ steps.latest-version.outputs.val }}..develop") and validate if a release is required.
             * Make sure the latest commit on `develop` has passed tests on the [CI](https://buildpacks.ci.cf-app.com/teams/main/pipelines/${{ github.event.repository.name }})
             * Refer [release instructions](https://github.com/pivotal-cf/tanzu-buildpacks/wiki/Releasing-CF-Buildpacks). (private link)


### PR DESCRIPTION
This shouldn't affect the workflow in any other repo.

Closes https://github.com/cloudfoundry/php-buildpack/issues/781
Related: https://github.com/cloudfoundry/buildpacks-ci/pull/222