### PR TITLE
Allows integration suites to be run as matrix

### DIFF
--- a/buildpack/.github/workflows/test-pull-request.yml
+++ b/buildpack/.github/workflows/test-pull-request.yml
@@ -24,10 +24,27 @@ jobs:
       - name: Run Unit Tests
         run: ./scripts/unit.sh
 
-  integration:
-    name: Integration Tests
+  integration-matrix:
+    name: Integration Matrix
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     needs: unit
+    steps:
+      - name: Set Matrix
+        id: set-matrix
+        run: |
+          matrix="$(jq -r -c '.integration.matrix' ./config.json)"
+          printf "Output: matrix=%s\n" "${matrix}"
+          printf "matrix=%s\n" "${matrix}"
+
+  integration:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    needs: integration-matrix
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.integration-matrix.outputs.matrix) }}
     steps:
 
       - name: Setup Go
@@ -43,13 +60,34 @@ jobs:
       - name: Run Integration Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./scripts/integration.sh --platform docker --github-token "${GITHUB_TOKEN}"
+        run: |
+          ./scripts/integration.sh \
+            --platform docker \
+            --github-token "${GITHUB_TOKEN}" \
+            --cached ${{ matrix.cached }} \
+            --parallel ${{ matrix.parallel }}
+
+  roundup:
+    name: Integration Tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: integration
+    steps:
+      - run: |
+          result="${{ needs.integration.result }}"
+          if [[ "${result}" == "success" ]]; then
+            echo "All integration tests passed"
+            exit 0
+          else
+            echo "One or more integration tests failed"
+            exit 1
+          fi
 
   approve:
     name: Approve Bot PRs
     if: ${{ github.event.pull_request.user.login == 'cf-buildpacks-eng' || github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
-    needs: integration
+    needs: roundup
     steps:
 
       - name: Check Commit Verification


### PR DESCRIPTION
We have a handful of integration suites that we are now running in GHA. Currently, these suites run a couple of permutations with caching enabled and disabled.

This change should allow these test suites to be run in parallel. It will also allow you to run just one of the permutations from the command line by specifying extra arguments to `./scripts/integration.sh`.