### PR TITLE
Use CGO_ENABLED=0 when building buildpack.

### DIFF
--- a/buildpack/scripts/build.sh
+++ b/buildpack/scripts/build.sh
@@ -29,6 +29,7 @@ function main() {
         output="${output}.exe"
       fi
 
+      CGO_ENABLED=0 \
       GOOS="${os}" \
         go build \
           -mod vendor \


### PR DESCRIPTION
This PR forces all buildpacks to be built with `CGO_ENABLED=0`. This avoids issues with glibc version compatibility when building with go 1.20.

See [this PR](https://github.com/paketo-buildpacks/github-config/pull/748) for context on similar issues with Paketo buildpacks