### PR TITLE
Go was being installed twice

### DIFF
--- a/buildpack/scripts/install_go.sh
+++ b/buildpack/scripts/install_go.sh
@@ -18,7 +18,7 @@ function main() {
 
   mkdir -p "${dir}"
 
-  if [[ ! -f "${dir}/go/bin/go" ]]; then
+  if [[ ! -f "${dir}/bin/go" ]]; then
     local url
     # TODO: use exact stack based dep, after go buildpack has cflinuxfs4 support
     #url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_${CF_STACK}_${expected_sha:0:8}.tgz"


### PR DESCRIPTION
# Context

The issue identified in https://github.com/cloudfoundry/nodejs-buildpack/issues/674 reveals that during the Buildpack run, Go is being installed twice. After debugging, it appears that the validation condition `if [[ ! -f "${dir}/go/bin/go" ]]` is evaluating the wrong folder. It should be corrected to `${dir}/go/bin/go`.
