### PR TITLE
Bump to latest go in helper script.

### DIFF
--- a/buildpack/scripts/install_go.sh
+++ b/buildpack/scripts/install_go.sh
@@ -12,8 +12,8 @@ function main() {
   fi
 
   local version expected_sha dir
-  version="1.19"
-  expected_sha="7e231ea5c68f4be7fea916d27814cc34b95e78c4664c3eb2411e8370f87558bd"
+  version="1.22.5"
+  expected_sha="ddb12ede43eef214c7d4376761bd5ba6297d5fa7a06d5635ea3e7a276b3db730"
   dir="/tmp/go${version}"
 
   mkdir -p "${dir}"


### PR DESCRIPTION
- We need a new enough version of go that recognizes changes to the go.mod - specifically that the go version now has three components not two.
