### PR TITLE
Bump actions versions to latest

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: stable
     - name: Checkout
       uses: actions/checkout@v3
     - name: Run Unit Tests

--- a/buildpack/.github/workflows/test-pull-request.yml
+++ b/buildpack/.github/workflows/test-pull-request.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19.x
+          go-version: stable
 
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run Unit Tests
         run: ./scripts/unit.sh
@@ -32,7 +32,7 @@ jobs:
     needs: unit
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set Matrix
         id: set-matrix
@@ -53,12 +53,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.19.x
+          go-version: stable
 
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* || true
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run Integration Tests
         env:

--- a/buildpack/.github/workflows/update-github-config.yml
+++ b/buildpack/.github/workflows/update-github-config.yml
@@ -2,7 +2,7 @@ name: Update shared github-config
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '10 9 * * *'
   workflow_dispatch: { }
 
 jobs:
@@ -12,13 +12,13 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CF_BOT_GITHUB_TOKEN }}
           ref: develop
 
       - name: Checkout github-config
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: cloudfoundry/buildpacks-github-config
           path: github-config


### PR DESCRIPTION
- also only check for github config updates once per day rather than every 15 mins.
