### PR TITLE
fix(install_go): Use Go 1.25.2 for cflinuxfs3 stack

### DIFF
--- a/buildpack/scripts/install_go.sh
+++ b/buildpack/scripts/install_go.sh
@@ -12,8 +12,13 @@ function main() {
   fi
 
   local version expected_sha dir
-  version="1.25.6"
-  expected_sha="0ed64e3b9cb9b1c2ec57880dae2427b0ee2676f2ae2fb53c2e1bb838c500f9fb"
+  if [[ "${CF_STACK}" == "cflinuxfs3" ]]; then
+    version="1.25.2"
+    expected_sha="385184a62bdcb565860663d365e2b28cdfbb6919d4439dae7e5cc87694a3dca6"
+  else
+    version="1.25.6"
+    expected_sha="0ed64e3b9cb9b1c2ec57880dae2427b0ee2676f2ae2fb53c2e1bb838c500f9fb"
+  fi
   dir="/tmp/go${version}"
 
   mkdir -p "${dir}"


### PR DESCRIPTION
Go 1.25.6 is not available for `cflinuxfs3`, so use Go 1.25.2 for that stack while keeping 1.25.6 for `cflinuxfs4`.

Fixes: https://github.com/cloudfoundry/go-buildpack/issues/556
