### PR TITLE
Fix Go 1.26 build compatibility: remove bin stubs before go build

### DIFF
--- a/buildpack/scripts/build.sh
+++ b/buildpack/scripts/build.sh
@@ -29,6 +29,7 @@ function main() {
         output="${output}.exe"
       fi
 
+      rm -f "${output}"
       CGO_ENABLED=0 \
       GOOS="${os}" \
         go build \


### PR DESCRIPTION
Fix Go 1.26 build compatibility: remove bin stubs before go build Go 1.26 refuses to overwrite non-object files with 'go build -o'. Add 'rm -f "${output}"' before each go build invocation so the shell script stubs in bin/ are removed first.